### PR TITLE
Dispose of the ChromiumWebBrowser before shutting down Cef

### DIFF
--- a/ChromePdf/Program.cs
+++ b/ChromePdf/Program.cs
@@ -104,6 +104,8 @@ namespace ChromePdf
             }
             catch { }
 
+            browser.Dispose();
+
             Cef.Shutdown();
         }
 


### PR DESCRIPTION
This cleans up event handlers and makes sure the Cef subprocess shuts down correctly